### PR TITLE
Use standardized official library name prefix

### DIFF
--- a/Arduino_PortentaBreakoutCarrier.h
+++ b/Arduino_PortentaBreakoutCarrier.h
@@ -2,7 +2,7 @@
 
 Arduino Library for the Arduino Portenta Breakout Carrier
 
-For more information about this library please visit us at https://www.arduino.cc/en/Reference/PortentaBreakoutCarrier
+For more information about this library please visit us at https://www.arduino.cc/en/Reference/Arduino_PortentaBreakoutCarrier
 
 == License ==
 
@@ -23,8 +23,8 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
-#ifndef _BREAKOUT_CARRIER_H
-#define _BREAKOUT_CARRIER_H
+#ifndef ARDUINO_PORTENTA_BREAKOUT_CARRIER_H
+#define ARDUINO_PORTENTA_BREAKOUT_CARRIER_H
 
 #include "Arduino.h"
 #include "pins_arduino.h"
@@ -192,4 +192,4 @@ public:
 
 BreakoutCarrierClass Breakout;
 
-#endif // _BREAKOUT_CARRIER_H
+#endif // ARDUINO_PORTENTA_BREAKOUT_CARRIER_H

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Arduino Library for the Arduino Portenta Breakout Carrier
 
-For more information about this library please visit us at https://www.arduino.cc/en/Reference/PortentaBreakoutCarrier
+For more information about this library please visit us at https://www.arduino.cc/en/Reference/Arduino_PortentaBreakoutCarrier
 
 == License ==
 

--- a/examples/GpioManagement/GpioManagement.ino
+++ b/examples/GpioManagement/GpioManagement.ino
@@ -11,7 +11,7 @@
 
   This example code is in the public domain.
 */
-#include "PortentaBreakoutCarrier.h"
+#include "Arduino_PortentaBreakoutCarrier.h"
 
 // The macros to access each gpio are made using the peripheral silk name
 // and the pin Name (e.g. the GPIO 0 pin can be accessed using

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
 #######################################
-# Syntax Coloring Map ForBreakoutCarrier
+# Syntax Coloring Map For Arduino_PortentaBreakoutCarrier
 ####################################### 
 # Class (KEYWORD1)
 #######################################

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
-name=PortentaBreakoutCarrier
+name=Arduino_PortentaBreakoutCarrier
 version=0.0.1
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Arduino Library for Arduino Portenta Breakout Carrier
 paragraph=
 category=
-url=https://github.com/arduino-libraries/PortentaBreakoutCarrier
+url=https://github.com/arduino-libraries/Arduino_PortentaBreakoutCarrier
 architectures=mbed
-includes=PortentaBreakoutCarrier.h
+includes=Arduino_PortentaBreakoutCarrier.h


### PR DESCRIPTION
The names of all new official libraries must start with "Arduino_". This creates a "namespace" to avoid collisions with names already claimed by 3rd party libraries and differentiates the official offerings from unvetted 3rd party libraries.

It's best practices for the following three things to be the same:

- Repository name
- library.properties name value
- Primary header file name

The library installation folder name is determined by the name value when installed via Library Manager.
The library installation folder name is determined by the repository name when installed via git clone or a .zip file download.
The reason it's important for the primary header file name to match the installation folder is because [File/folder name matching](https://arduino.github.io/arduino-cli/latest/sketch-build-process/#folder-name-priority) is one factor used to determine priority during dependency resolution.

For this reason, this commit renames the header file in parallel with the name value. It is not possible to rename the
repository via a commit so that must be done separately.