### PR TITLE
Use Markdown markup in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-= Portenta Breakout Carrier Library for Arduino =
+# Portenta Breakout Carrier Library for Arduino
 
 Arduino Library for the Arduino Portenta Breakout Carrier
 
 For more information about this library please visit us at https://www.arduino.cc/en/Reference/PortentaBreakoutCarrier
 
-== License ==
+## License
 
 Copyright (c) 2021 Arduino SA. All rights reserved.
 


### PR DESCRIPTION
The file type of the readme is Markdown, but it was using AsciiDoc markup.