### PR TITLE
Use most appropriate #include directive syntax

### DIFF
--- a/PortentaBreakoutCarrier.h
+++ b/PortentaBreakoutCarrier.h
@@ -26,9 +26,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 #ifndef _BREAKOUT_CARRIER_H
 #define _BREAKOUT_CARRIER_H
 
-#include "Arduino.h"
-#include "pins_arduino.h"
-#include "mbed.h"
+#include <Arduino.h>
+#include <pins_arduino.h>
+#include <mbed.h>
 
 #define LAST_ARDUINO_PIN_NUMBER LEDB + 1
 typedef enum {

--- a/examples/GpioManagement/GpioManagement.ino
+++ b/examples/GpioManagement/GpioManagement.ino
@@ -11,7 +11,7 @@
 
   This example code is in the public domain.
 */
-#include "PortentaBreakoutCarrier.h"
+#include <PortentaBreakoutCarrier.h>
 
 // The macros to access each gpio are made using the peripheral silk name
 // and the pin Name (e.g. the GPIO 0 pin can be accessed using


### PR DESCRIPTION
The files in these `#include` directives are external dependencies, so the angle brackets syntax is most appropriate.

Although either syntax will work, use of the most appropriate syntax communicates intent.