### PR TITLE
Fix multiple definition errors when using library header in two different files

### DIFF
--- a/src/Arduino_PortentaBreakout.cpp
+++ b/src/Arduino_PortentaBreakout.cpp
@@ -1,0 +1,3 @@
+#include "Arduino_PortentaBreakout.h"
+
+BreakoutCarrierClass Breakout;

--- a/src/Arduino_PortentaBreakout.h
+++ b/src/Arduino_PortentaBreakout.h
@@ -268,6 +268,6 @@ public:
     }
 };
 
-BreakoutCarrierClass Breakout;
+extern BreakoutCarrierClass Breakout;
 
 #endif // ARDUINO_PORTENTA_BREAKOUT_H


### PR DESCRIPTION
Since this library **defines** the `Breakout` object in its header file, it's a death sentence for users wanting to use the header file from two different .cpp files, as such is common in IDEs like PlatformIO + VSCode, since that causes `multiple definition of` errors.

Users are running into this error [for example here](https://community.platformio.org/t/collect2-exe-error-ld-returned-1-exit-status-cannot-find-how-to-solve-it/23951/4?u=maxgerhardt).

This PR fixes this error by only declaring the breakout object to be `extern` and then adding a `.cpp` file in which the object is then created once.